### PR TITLE
Fix memoization of localizer data, add benchmark

### DIFF
--- a/lctime.go
+++ b/lctime.go
@@ -137,23 +137,22 @@ func loadLocale(id string) (*localeData, error) {
 	id = removeCodeset(id)
 	if l, ok := loaded.Load(id); ok {
 		lc, ok := l.(*localeData)
-		if !ok {
+		if ok {
 			return lc, nil
 		}
 	}
 
-	// All locales use UTF-8.
-	var lc localeData
 	bys, err := locale.Asset(id + ".json")
 	if err != nil {
-		lc = localeData{}
 		return nil, ErrNoLocale
 	}
 
-	if err = json.Unmarshal(bys, &lc); err != nil {
-		lc = localeData{}
+	// All locales use UTF-8.
+	var lc localeData
+	if err := json.Unmarshal(bys, &lc); err != nil {
 		return nil, ErrCorruptLocale
 	}
+	
 	loaded.Store(id, &lc)
 	return &lc, nil
 }

--- a/lctime_test.go
+++ b/lctime_test.go
@@ -124,3 +124,18 @@ func TestRemoveCodeset(t *testing.T) {
 		}
 	}
 }
+
+var loc Localizer
+
+func BenchmarkNewLocalizer(b *testing.B) {
+	var lc Localizer
+	for i := 0; i < b.N; i++ {
+		l, err := NewLocalizer("en_US")
+		if err != nil {
+			b.Fatalf("NewLocalizer(): %s", err)
+		}
+
+		lc = l
+	}
+	loc = lc
+}


### PR DESCRIPTION
Benchmark output

	go test -benchmem -run=^$ github.com/klauspost/lctime -bench ^(BenchmarkNewLocalizer)$

	goos: darwin
	goarch: amd64
	pkg: github.com/klauspost/lctime

	BEFORE:
	BenchmarkNewLocalizer-12    	   43866	     27375 ns/op	   46368 B/op	      94 allocs/op
	PASS
	ok  	github.com/klauspost/lctime	3.591s

	AFTER:
	BenchmarkNewLocalizer-12    	33426420	        35.8 ns/op	       0 B/op	       0 allocs/op
	PASS
	ok  	github.com/klauspost/lctime	2.929s